### PR TITLE
Add detection of M9 (SPG) and disable RXM-RAWX for M9. Also tidy up other detections.

### DIFF
--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -709,19 +709,21 @@ int main(int argc, char** argv)
       for(unsigned int n=0; 40+30*n < um1.getPayload().size(); ++n) {
         string line = (const char*)um1.getPayload().c_str() + 40 +30*n;
         cerr<<humanTimeNow()<<" Extended info: "<<line <<endl;
-        
-        if(line.find("F9") != string::npos)
-          version9=true;
-
-        if(line.find("M8T") != string::npos) {
-          m8t=true;
-        }
 
         if(line.find("MOD=") != string::npos)
           mods += line.substr(4);
-        
-        // timing: MOD=NEO-M8T-0
-        
+      }
+
+      if(mods.find("F9") != string::npos) {
+        /* F9 supports dual-frequency */
+        cerr<<humanTimeNow()<<" Detected version U-Blox F9"<<endl;
+        version9=true;
+      }
+
+      if(mods.find("M8T") != string::npos) {
+        /* Timing modules can be surveyed in */
+        cerr<<humanTimeNow()<<" Detected timing module"<<endl;
+        m8t=true;
       }
 
       if(mods.find("M9") != string::npos) {
@@ -742,8 +744,6 @@ int main(int argc, char** argv)
       
       cerr<<humanTimeNow()<<" Serial number "<< serialno <<endl;
 
-      if(version9)
-        cerr<<humanTimeNow()<<" Detected version U-Blox 9"<<endl;
       usleep(50000);
       if (doDEBUG) { cerr<<humanTimeNow()<<" Sending GNSS query"<<endl; }
       msg = buildUbxMessage(0x06, 0x3e, {});

--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -658,6 +658,7 @@ int main(int argc, char** argv)
   if(doFakeFix) // hack
     version9 = true;
   bool m8t = false;
+  bool m9 = false;
 
   string hwversion;
   string swversion;
@@ -722,7 +723,13 @@ int main(int argc, char** argv)
         // timing: MOD=NEO-M8T-0
         
       }
-      if (doDEBUG && m8t) { cerr<<humanTimeNow()<<" Detected timing module"<<endl; }
+
+      if(mods.find("M9") != string::npos) {
+        /* M9 doesn't support RXM-RAWX */
+        cerr<<humanTimeNow()<<" Detected U-Blox M9"<<endl;
+        m9=true;
+      }
+
       if (doDEBUG) { cerr<<humanTimeNow()<<" Sending serial number query"<<endl; }
       msg = buildUbxMessage(0x27, 0x03, {});
       um1=sendAndWaitForUBX(fd, 1, msg, 0x27, 0x03); // ask for serial
@@ -985,8 +992,10 @@ int main(int argc, char** argv)
         enableUBXMessageOnPort(fd, 0x0d, 0x04, ubxport, 2);       
       }
 
-      if (doDEBUG) { cerr<<humanTimeNow()<<" Enabling UBX-RXM-RAWX"<<endl; } // RF doppler
-      enableUBXMessageOnPort(fd, 0x02, 0x15, ubxport, 8); // RXM-RAWX
+      if(!m9) {
+        if (doDEBUG) { cerr<<humanTimeNow()<<" Enabling UBX-RXM-RAWX"<<endl; } // RF doppler
+        enableUBXMessageOnPort(fd, 0x02, 0x15, ubxport, 8); // RXM-RAWX
+      }
 
       if (doDEBUG) { cerr<<humanTimeNow()<<" Enabling UBX-NAV-CLOCK"<<endl; } // clock details
       enableUBXMessageOnPort(fd, 0x01, 0x22, ubxport, 16); // UBX-NAV-CLOCK


### PR DESCRIPTION
These changes add detection of the u-blox M9 chipset - unfortunately the M9 doesn't support RXM-RAWX (will NAK it) and so this detection is then used to disable that message for the M9.

This change also tidies up other detections, running the string matches on the 'MOD=' string raw than raw input.

The M9 is a standard precision (no raw), L1-only, but quad-concurrent-constellation module.

This proposed changeset is currently running with a USB-connected NEO-M9N at [https://galmon.eu/observer.html?observer=227](https://galmon.eu/observer.html?observer=227)