### PR TITLE
ubxtool.cc: Use monotonic clock for uptime calculation.

### DIFF
--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -565,7 +565,7 @@ int initFD(const char* fname, bool doRTSCTS)
 // ubxtool device srcid
 int main(int argc, char** argv)
 {
-  time_t starttime=time(0);
+  auto starttime = std::chrono::steady_clock::now();
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   CLI::App app(program);
@@ -1629,7 +1629,7 @@ int main(int argc, char** argv)
         nmm.mutable_od()->set_owner(owner);
         nmm.mutable_od()->set_remark(remark);
         nmm.mutable_od()->set_recvgithash(g_gitHash);
-        nmm.mutable_od()->set_uptime(time(0) - starttime);
+        nmm.mutable_od()->set_uptime(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now()-starttime).count());
         
         
         ns.emitNMM( nmm);


### PR DESCRIPTION
Uses monotonic clock for uploaded uptime calculation to fix #108 .

There are other areas where a non-monotonic clock is used to trigger the output of display messages, resulting in extra messages when the clock jumps, however this wasn't included in the fix as in that case no incorrect data is displayed.