### PR TITLE
Add docker image building via github actions.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Set up docker buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      - name: Login to docker registry
+        run: |
+          docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_TOKEN }}
+      - name: Run buildx
+        run: |
+          docker buildx build \
+            --tag galmon/galmon \
+            --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8 \
+            --output "type=registry" \
+            --build-arg MAKE_FLAGS=-j1 \
+            --file Dockerfile \
+            .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:eoan
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL C.UTF-8

--- a/README.md
+++ b/README.md
@@ -92,22 +92,29 @@ library installed. If you get an error about 'wslay', do the following, and run 
 echo WSLAY=-lwslay > Makefile.local
 ```
 
-Build in Docker
----------------
+Running in Docker
+-----------------
 
-To build it in Docker:
+We publish official Docker images for galmon on
+[docker hub](https://hub.docker.com/r/faucet/faucet) for multiple architectures.
 
-```
-git clone https://github.com/ahupowerdns/galmon.git --recursive
-docker build -t galmon --build-arg MAKE_FLAGS=-j2 .
-```
-
-To run a container with a shell in there (this will also expose a port so you can view the UI too and assumes a ublox GPS device too - you may need to tweak as necessary):
+To run a container with a shell in there (this will also expose a port so you
+can view the UI too and assumes a ublox GPS device too -
+you may need to tweak as necessary):
 
 ```
-docker run -it --rm --device=/dev/ttyACM0 -p 10000:10000 galmon
+docker run -it --rm --device=/dev/ttyACM0 -p 10000:10000 galmon/galmon
 ```
 
+Running a daemonized docker container reporting data to a remote server
+might look like:
+
+```
+docker run -d --restart=always --device=/dev/ttyACM0 --name=galmon galmon/galmon /galmon/ubxtool --wait --port /dev/ttyACM0 --gps --galileo --glonass --destination [server] --station [station-id] --owner [owner]
+```
+
+To make your docker container update automatically you could use a tool such as
+[watchtower](https://containrrr.github.io/watchtower/).
 
 Running
 -------


### PR DESCRIPTION
Build official docker images for galmon and publish on docker hub.

The purpose of this PR is to save everyone some CPU cycles by building galmon once and distributing this built docker image (rather than everyone having to build it themselves).

There are some manual steps that need to be performed before this PR is merged:

  1. Sign up for a docker hub account for galmon: https://hub.docker.com/signup
  2. Generate an access token: https://hub.docker.com/settings/security
  3. Go to https://github.com/ahupowerdns/galmon/settings/secrets, create a `DOCKER_USERNAME` secret which is set to the same as your docker hub account, create a `DOCKER_TOKEN` which is set to the access token created in step 2.