### PR TITLE
Update official docker image name in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Running in Docker
 -----------------
 
 We publish official Docker images for galmon on
-[docker hub](https://hub.docker.com/r/faucet/faucet) for multiple architectures.
+[docker hub](https://hub.docker.com/r/galmon/galmon) for multiple architectures.
 
 To run a container with a shell in there (this will also expose a port so you
 can view the UI too and assumes a ublox GPS device too -


### PR DESCRIPTION
Replace incorrect official docker hub name in README.md.

Note: this is a draft PR as the `galmon` name on docker hub has already been taken by somebody else.

TODO: I also need to update the name in `.github/workflows/docker.yml`