### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -O3 -Wall -ggdb 
 
-CXXFLAGS:= -std=gnu++17 -Wall -O3 -ggdb -MMD -MP -fno-omit-frame-pointer -Iext/CLI11 \
+CXXFLAGS:= -std=gnu++17 $(CFLAGS) -MMD -MP -fno-omit-frame-pointer -Iext/CLI11 \
 	 -Iext/fmt-6.1.2/include/ -Iext/powerblog/ext/simplesocket -Iext/powerblog/ext/ \
 	 -I/usr/local/opt/openssl/include/  \
 	 -Iext/sgp4/libsgp4/ \


### PR DESCRIPTION
The Makefile has `CFLAGS` and `CXXFLAGS` and they seem to not be in sync or better put, they duplicated functionality. This fix allows anyone to run a make with the following command (should they need a quick build): `make ubxtool CFLAGS=-O0`.