### PR TITLE
Update official docker image name in README.md.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run buildx
         run: |
           docker buildx build \
-            --tag galmon/galmon \
+            --tag berthubert/galmon \
             --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8 \
             --output "type=registry" \
             --build-arg MAKE_FLAGS=-j1 \

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Running in Docker
 -----------------
 
 We publish official Docker images for galmon on
-[docker hub](https://hub.docker.com/r/faucet/faucet) for multiple architectures.
+[docker hub](https://hub.docker.com/r/berthubert/galmon) for multiple architectures.
 
 To run a container with a shell in there (this will also expose a port so you
 can view the UI too and assumes a ublox GPS device too -


### PR DESCRIPTION
The [galmon](https://hub.docker.com/u/galmon) name is already taken on docker hub, but [berthubert](https://hub.docker.com/u/berthubert) is free which matches the git repo name.