### PR TITLE
ubxtool: Log the size of the 'svseen' set in "currently receiving" message

### DIFF
--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -1322,7 +1322,7 @@ int main(int argc, char** argv)
           svseen.insert({id.first, id.second, payload[2]});
 
           if(time(0)- lastStat > 30) {
-            cerr<<humanTimeNow()<<" src "<<g_srcid<< " (fix: "<<g_fixtype<<") currently receiving: ";
+            cerr<<humanTimeNow()<<" src "<<g_srcid<< " (fix: "<<g_fixtype<<") currently receiving ("<<svseen.size()<<"): ";
             for(auto& s : svseen) {
               cerr<<get<0>(s)<<","<<get<1>(s)<<"@"<<get<2>(s)<<" ";
             }


### PR DESCRIPTION
This commit updates the "... currently receiving ..." log message to include the size of the `svseen` set. It's hard to eyeball this figure with the current log format, especially if the output has been wrapped or truncated.

Example of new output:

    Sun, 20 Sep 2020 19:50:25 +0000 swVersion: ROM CORE 3.01 (107888)
    Sun, 20 Sep 2020 19:50:25 +0000 hwVersion: 00080000
    Sun, 20 Sep 2020 19:50:25 +0000 Extended info: FWVER=SPG 3.01
    Sun, 20 Sep 2020 19:50:25 +0000 Extended info: PROTVER=18.00
    Sun, 20 Sep 2020 19:50:25 +0000 Extended info: GPS;GLO;GAL;BDS
    Sun, 20 Sep 2020 19:50:25 +0000 Extended info: SBAS;IMES;QZSS
    Sun, 20 Sep 2020 19:50:25 +0000 Serial number f3044f0761
    Sun, 20 Sep 2020 19:50:25 +0000 Entering main loop
    Sun, 20 Sep 2020 19:50:29 +0000 src 71 (fix: 3) currently receiving (1): 2,9@1
    Sun, 20 Sep 2020 19:51:00 +0000 src 71 (fix: 3) currently receiving (15): 0,10@0 0,15@0 0,18@0 0,20@0 0,23@0 0,27@0 0,32@0 2,4@1 2,5@1 2,9@1 2,36@1 6,3@0 6,4@0 6,17@0 6,18@0
    Sun, 20 Sep 2020 19:51:31 +0000 src 71 (fix: 3) currently receiving (15): 0,10@0 0,15@0 0,18@0 0,20@0 0,23@0 0,27@0 0,32@0 2,4@1 2,5@1 2,9@1 2,36@1 6,3@0 6,4@0 6,17@0 6,18@0
    Sun, 20 Sep 2020 19:52:02 +0000 src 71 (fix: 3) currently receiving (15): 0,10@0 0,15@0 0,18@0 0,20@0 0,23@0 0,27@0 0,32@0 2,4@1 2,5@1 2,9@1 2,36@1 6,3@0 6,4@0 6,17@0 6,18@0
    Sun, 20 Sep 2020 19:52:33 +0000 src 71 (fix: 3) currently receiving (15): 0,10@0 0,15@0 0,18@0 0,20@0 0,23@0 0,27@0 0,32@0 2,4@1 2,5@1 2,9@1 2,36@1 6,3@0 6,4@0 6,17@0 6,18@0
    Sun, 20 Sep 2020 19:53:04 +0000 src 71 (fix: 3) currently receiving (16): 0,10@0 0,15@0 0,18@0 0,20@0 0,23@0 0,27@0 0,32@0 2,4@1 2,5@1 2,9@1 2,11@1 2,36@1 6,2@0 6,3@0 6,4@0 6,18@0
    Sun, 20 Sep 2020 19:53:35 +0000 src 71 (fix: 3) currently receiving (16): 0,10@0 0,15@0 0,18@0 0,20@0 0,23@0 0,27@0 0,32@0 2,4@1 2,5@1 2,9@1 2,11@1 2,36@1 6,3@0 6,4@0 6,17@0 6,18@0
    Sun, 20 Sep 2020 19:54:06 +0000 src 71 (fix: 3) currently receiving (17): 0,10@0 0,15@0 0,18@0 0,20@0 0,23@0 0,27@0 0,32@0 2,4@1 2,5@1 2,9@1 2,11@1 2,36@1 6,3@0 6,4@0 6,12@0 6,17@0 6,18@0