### PR TITLE
Update docker build to use supported github action

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,6 +1,6 @@
 name: C/C++ CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,12 +12,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Checkout submodules
         run: git submodule update --init --recursive
+      - name: Set up qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
       - name: Set up docker buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
+        uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
-          qemu-version: latest
+          version: latest
       - name: Login to docker registry
         run: |
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
* The crazy-max/ghaction-docker-buildx action has been deprecated, replace it with official docker/setup-buildx-action.
* Enable C/C++ CI workflow on github pull request so we can see test suite status before merging a PR.