### PR TITLE
Add UBX-over-UDP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ to stdout, add `--stdout`.
 
 Tooling:
 
- * ubxtool: can configure a u-blox 8 chipset, parses its output & will
+ * ubxtool: can configure a u-blox 8/9 chipset, parses its output & will
    convert it into a protbuf stream of GNSS NAV frames + metadata
    Adds 64-bit timestamps plus origin information to each message
  * septool: ingests the Septentrio binary format (SBF) and converts it to our
@@ -453,4 +453,5 @@ ubxtool
    start date)
  * Can also read from disk
  * Careful to add the right timestamps
-
+ * Can send UBX protocol messages as UDP datagrams (using the `--udp-ubx`)
+   command-line argument; this can be used to feed GNSS data to `gpsd`


### PR DESCRIPTION
`ubxtool` can now forward UBX messages as UDP datagrams; this can be used to feed them to `gpsd`, avoiding the need
for `gpsd` to have its own connection to the GPS receiver.

The `--udp-ubx` command line argument accepts an IPv4/6 address-and-port as the destination to receive the datagrams.